### PR TITLE
Terraform 0.15 compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_sns_topic" "pagerduty" {
 }
 
 locals {
-  sns_topic_arn = element(concat(aws_sns_topic.pagerduty.*.arn, data.aws_sns_topic.pagerduty.*.arn, list("")), 0)
+  sns_topic_arn = coalesce(aws_sns_topic.pagerduty.*.arn, data.aws_sns_topic.pagerduty.*.arn)
 }
 
 resource "aws_sns_topic_subscription" "pagerduty" {

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_sns_topic" "pagerduty" {
 }
 
 locals {
-  sns_topic_arn = coalesce(aws_sns_topic.pagerduty.*.arn[0], data.aws_sns_topic.pagerduty.*.arn[0])
+  sns_topic_arn = coalescelist(aws_sns_topic.pagerduty.*.arn, data.aws_sns_topic.pagerduty.*.arn)[0]
 }
 
 resource "aws_sns_topic_subscription" "pagerduty" {

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_sns_topic" "pagerduty" {
 }
 
 locals {
-  sns_topic_arn = coalesce(aws_sns_topic.pagerduty.*.arn, data.aws_sns_topic.pagerduty.*.arn)
+  sns_topic_arn = coalesce(aws_sns_topic.pagerduty.*.arn[0], data.aws_sns_topic.pagerduty.*.arn[0])
 }
 
 resource "aws_sns_topic_subscription" "pagerduty" {


### PR DESCRIPTION
The list() function was deprecated in v0.15 of terraform.

This new syntax achieves the same result